### PR TITLE
Fixes event date/time mangling

### DIFF
--- a/pull-mit-events.php
+++ b/pull-mit-events.php
@@ -80,6 +80,14 @@ public function field_callback( $arguments ) {
 
 static function pull_events( $confirm = false ) {
 
+	/**
+	 * Before we do anything, make sure our timezone is set correctly based on
+	 * the site settings. Ideally we would store times and dates in their proper
+	 * format, but it was a legacy decision that they would be stored as
+	 * strings, rather than datetimes.
+	 */
+	date_default_timezone_set( get_option( 'timezone_string' ) );
+
 	$url = EVENTS_URL; 
 	$result = file_get_contents($url);
 	$events = json_decode($result, TRUE);
@@ -88,7 +96,6 @@ static function pull_events( $confirm = false ) {
 			if (isset($val["event"]["title"])) { 
 				$title =  $val["event"]["title"];
 				$slug = str_replace(" ", "-", $title);
-
 			}
 			if (isset($val["event"]["description_text"])) { 
 				$description = $val["event"]["description_text"];

--- a/pull-mit-events.php
+++ b/pull-mit-events.php
@@ -101,13 +101,18 @@ static function pull_events( $confirm = false ) {
 				$description = $val["event"]["description_text"];
 			}
 			if (isset($val["event"]["event_instances"][0]["event_instance"])) { 
+				$calendar_id =  $val["event"]["event_instances"][0]["event_instance"]["id"];
 				$start =  strtotime($val["event"]["event_instances"][0]["event_instance"]["start"]);
-				$end =  strtotime($val["event"]["event_instances"][0]["event_instance"]["end"]);
 				$startdate = date('Ymd', $start);
 				$starttime = date('h:i A', $start);
-				$enddate = date('Ymd', $end);
-				$endtime = date('h:i A', $end);
-				$calendar_id =  $val["event"]["event_instances"][0]["event_instance"]["id"];	
+				$end = '';
+				$enddate = '';
+				$endtime = '';
+				if ( isset( $val["event"]["event_instances"][0]["event_instance"]["end"] ) ) {
+					$end =  strtotime($val["event"]["event_instances"][0]["event_instance"]["end"]);
+					$enddate = date('Ymd', $end);
+					$endtime = date('h:i A', $end);
+				}
 			}
 			if (isset($val["event"]["localist_url"])) { 
 				$calendar_url =  $val["event"]["localist_url"];
@@ -181,7 +186,9 @@ static function pull_events( $confirm = false ) {
 				}
 				Pull_Events_Plugin::__update_post_meta( $post_id, 'event_date' , $startdate );
 				Pull_Events_Plugin::__update_post_meta( $post_id, 'event_start_time' , $starttime );	
-				Pull_Events_Plugin::__update_post_meta( $post_id,  'event_end_time' , $endtime );
+				if ( isset( $val["event"]["event_instances"][0]["event_instance"]["end"] ) ) {
+					Pull_Events_Plugin::__update_post_meta( $post_id,  'event_end_time' , $endtime );
+				}
 				Pull_Events_Plugin::__update_post_meta( $post_id,  'is_event' , '1' );
 				Pull_Events_Plugin::__update_post_meta( $post_id,  'calendar_url' , $calendar_url );
 				Pull_Events_Plugin::__update_post_meta( $post_id,  'calendar_id' , $calendar_id );

--- a/pull-mit-events.php
+++ b/pull-mit-events.php
@@ -3,7 +3,7 @@
 Plugin Name: Pull MIT Events
 Description: Pulls Events from calendar.mit.edu for the Libraries news site 
 Author: Hattie Llavina
-Version: 1.0
+Version: 1.0.1
 */
 
 


### PR DESCRIPTION
## Status
_Use labels (`review needed`, `in progress`, or `paused`) to declare status_

#### What does this PR do?
This alters the plugin's import behavior in two ways:
1. It explicitly sets the timezone based on the WordPress site's timezone setting (relying on the timezone to be set via a value such as `America/New_York` rather than `UTC-4`). This causes the imported times to be converted and stored correctly via the fields set up by the Advanced Custom Fields plugin.
2. It adds a sanity check before setting the end time for any imported event. Without this check, a default value is used that ends up mistakenly reporting that events end at 7 PM.

#### Helpful background context (if appropriate)
Brigham has reported that some event records are being imported with times that are incorrectly set. These take two forms:
1. Events without an explicitly set end time are seeing a default value of 7 PM.
2. All imported times are off by four hours.

This change _does not_ address a pre-existing design problem wherein times are stored as strings within WordPress. As a result, the plugin needs to handle time conversions itself rather than simply storing the imported value directly, and letting the theme layer handle the times in a way more consistent with best practices.

It is possible that future work will correct this deficiency in the data model. Given the looming site redesign, however, it might not be the best use of time to embark on this change now.

*Please note:*
The linting tools run by CodeClimate and Travis are currently failing all work on this plugin due to existing standards violations. The work to correct (or whitelist) these violations is underway in a separate branch, but is not included here. The plan is to finish that work after this branch merges.

#### How can a reviewer manually see the effects of these changes?
No tests exist unfortunately. The best way to verify operation would probably be to look at the dev or test servers, both of which have this branch deployed and have re-run their import proccesses. Ask Matt for the URLs. If the imported records as displayed on the dev/test sites correspond to the times reported by the MIT Calendar, then things are working correctly.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/NTI-263 (end time being set incorrectly)
- https://mitlibraries.atlassian.net/browse/NTI-332 (times off by four hours)

#### Requires new or updated plugins, themes, or libraries?
NO

#### Requires change to deploy process?
NO
